### PR TITLE
fix: enable starship in home-manager with zsh integration

### DIFF
--- a/configuration.nix
+++ b/configuration.nix
@@ -225,9 +225,7 @@
       enable = true;
       defaultEditor = true; # $EDITOR=nvim
     };
-    starship = {
-      enable = true;
-    };
+
     zsh = {
       enable = true;
     };

--- a/modules/home/common/starship.nix
+++ b/modules/home/common/starship.nix
@@ -1,5 +1,7 @@
 _: {
   programs.starship = {
+    enable = true;
+    enableZshIntegration = true;
   };
   home.file."./.config/starship.toml".text = ''
     format = """


### PR DESCRIPTION
## 概要
starshipをhome-managerで有効化し、zsh統合に変更

## 変更内容
- starshipをhome-managerレベルで有効化
- bash統合からzsh統合に変更
- configuration.nixの重複したstarship設定を削除

## 動作確認
`home-manager switch --flake .`実行後、starshipが正しく動作することを確認してください