### PR TITLE
Add jujutsu (jj) Git alternative tool

### DIFF
--- a/configuration.nix
+++ b/configuration.nix
@@ -221,6 +221,9 @@
     git = {
       enable = true;
     };
+    jujutsu = {
+      enable = true;
+    };
     neovim = {
       enable = true;
       defaultEditor = true; # $EDITOR=nvim


### PR DESCRIPTION
This PR adds jujutsu (jj) as a Git alternative tool by enabling it in configuration.nix.