### PR TITLE
feat: relocate jujutsu configuration to shared home-manager module

### DIFF
--- a/configuration.nix
+++ b/configuration.nix
@@ -221,9 +221,6 @@
     git = {
       enable = true;
     };
-    jujutsu = {
-      enable = true;
-    };
     neovim = {
       enable = true;
       defaultEditor = true; # $EDITOR=nvim

--- a/modules/home/common/default.nix
+++ b/modules/home/common/default.nix
@@ -12,6 +12,7 @@
     ./direnv.nix
     ./gh.nix
     ./git.nix
+    ./jujutsu.nix
     ./starship.nix
     ./zoxide.nix
     ./zsh.nix

--- a/modules/home/common/jujutsu.nix
+++ b/modules/home/common/jujutsu.nix
@@ -1,4 +1,4 @@
-{pkgs, ...}: {
+{
   programs.jujutsu = {
     enable = true;
   };

--- a/modules/home/common/jujutsu.nix
+++ b/modules/home/common/jujutsu.nix
@@ -1,0 +1,5 @@
+{pkgs, ...}: {
+  programs.jujutsu = {
+    enable = true;
+  };
+}


### PR DESCRIPTION
Relocates jujutsu (jj) configuration from configuration.nix to a shared Home Manager module to ensure availability in all environments.